### PR TITLE
Added support for absolute and relative xpath locator types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ locators defined, then `en_US` is to be used as the fall back locale and `en_US`
        some conventions associated with this :
           1. **xpath format** : Can be of the form `xpath=./input[@name='first_name']` (or) `xpath=//input[@name='first_name']` 
           (or) `xpath=/input[@name='first_name']` (or) `xpath=(//input[@class='btn'])[1]`
+          (or) `./input[@name='first_name']` (or) `//input[@name='first_name']` (or) `/input[@name='first_name']`
           2. **css format** : Can be of the form `css=input[name='first_name']`
           3. **id (or) name format** : Can be of the form `first_name` { here `first_name` can either be the `id` of 
           an element (or) the `name` of an element. }
@@ -136,6 +137,19 @@ Lets say we have the below json sample which is located in `src/test/resources/H
         {
           "name": "en_US",
           "locator": "xpath=//h1[@class='heading']"
+        }
+      ],
+      "wait": {
+        "until": "visible",
+        "for": 45
+      }
+    },
+    {
+      "name": "heading1",
+      "locale": [
+        {
+          "name": "en_US",
+          "locator": "//h1[@class='heading1']"
         }
       ],
       "wait": {

--- a/src/main/java/com/rationaleemotions/internal/locators/Strategy.java
+++ b/src/main/java/com/rationaleemotions/internal/locators/Strategy.java
@@ -148,15 +148,20 @@ public enum Strategy implements StrategyTraits {
         }
     };
 
+    private static final String DEFAULT_REGEXP_PATTERN_XPATH_IDENTIFIER = "^(/|//|./|.//).*$";
+
     private static boolean isNotNullAndEmpty(String locator) {
         return locator != null && ! locator.trim().isEmpty();
     }
 
     private static boolean matches(String locator, String type) {
-        return Strategy.isNotNullAndEmpty(locator) && locator.toLowerCase().startsWith(type.toLowerCase());
+        return Strategy.isNotNullAndEmpty(locator) && (locator.toLowerCase().startsWith(type.toLowerCase().trim()) || locator.toLowerCase().trim().matches(DEFAULT_REGEXP_PATTERN_XPATH_IDENTIFIER));
     }
 
     private static String extractLocator(String locator, String type) {
+        if (locator.trim().matches(DEFAULT_REGEXP_PATTERN_XPATH_IDENTIFIER)) {
+            return locator;
+        }
         return locator.substring(type.length() + 1);
     }
 

--- a/src/test/java/com/rationaleemotions/internal/locators/StrategyTest.java
+++ b/src/test/java/com/rationaleemotions/internal/locators/StrategyTest.java
@@ -29,7 +29,14 @@ public class StrategyTest {
                 {"linkText=", By.ByLinkText.class},
                 {"partialLinkText=", By.ByPartialLinkText.class},
                 {"tagName=", By.ByTagName.class},
-                {"foo", ByIdOrName.class}
+                {"foo", ByIdOrName.class},
+                {"//h1", By.ByXPath.class},
+                {"//*", By.ByXPath.class},
+                {"/html/body/h1", By.ByXPath.class},
+                {"  //", By.ByXPath.class},
+                {"//label[@id='message23']", By.ByXPath.class},
+                {"./h1", By.ByXPath.class},
+                {" ./html/body/table", By.ByXPath.class}
             };
         }
         return new Object[][] {


### PR DESCRIPTION
1. Supports Absolute, Relative xpath locators which can start with - "//", "/", "./"
2. Added tests for newly supported xpath locator type for both absolute and relative types.
3. Updated readme file for supported xpath locators with json example