### PR TITLE
Bump testng, commons-io and gson to the latest version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.1.0</version>
+            <version>7.4.0</version>
             <scope>test</scope>
         </dependency>
         <!--Selenium is required for the UI automation support -->
@@ -63,13 +63,13 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.3.2</version>
+            <version>2.11.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.5</version>
+            <version>2.8.9</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
This PR bumps up following artifacts to their latest version as given below : 

1. TestNG : 7.1.0 -> 7.4.0
2. Commons-IO : 1.3.2 -> 2.11.0
3. Gson : 2.8.5 -> 2.8.9