### PR TITLE
Added fixes for the reported CVE-2022-25647 vulnerability on simple-se-pageobjects v1.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.9</version>
+            <version>2.9.1</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
* Added fixes for the reported CVE-2022-25647 vulnerability on simple-se-pageobjects v1.0.6

Issue Identified Link : https://mvnrepository.com/artifact/com.rationaleemotions/simple-se-pageobjects/1.0.6
Reported CVE Description : https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25647